### PR TITLE
Connect filter score UI to score drawer

### DIFF
--- a/lib/data/drift_db.dart
+++ b/lib/data/drift_db.dart
@@ -25,6 +25,10 @@ class AppDb extends _$AppDb {
   }
   // get all score records
   Future<List<Score>> get allScoresDb => select(scores).get();
+  // delete records by bulk or individual
+  Future deleteListOfScoresDB(List<int> listOfIds){
+    return (delete(scores)..where((score)=>score.id.isIn(listOfIds))).go();
+  }
 
   // Note: this is for migration, so not applicable yet.
   // you should bump this number whenever you change or add a table definition.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:modal_side_sheet/modal_side_sheet.dart';
 import 'package:musescore/widgets/BookMarkDrawer.dart';
 import 'package:musescore/widgets/ScoresDrawer.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import './widgets/MainDrawer.dart';
 import './widgets/SetlistDrawer.dart';
@@ -18,7 +19,7 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await injector.setupLocator();
   cameras = await availableCameras();
-  runApp(AppEntry());
+  runApp(ProviderScope(child: AppEntry()));
 }
 
 class AppEntry extends StatelessWidget {
@@ -39,10 +40,10 @@ class AppEntry extends StatelessWidget {
 
 class TopBar extends StatefulWidget {
   @override
-  State<TopBar> createState() => _TopBarState();
+  State<StatefulWidget> createState() => _TopBarState();
 }
 
-class _TopBarState extends State<TopBar> {
+class _TopBarState extends State {
   @override
   Widget build(BuildContext context) {
     final mediaQuerry = MediaQuery.of(context);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,10 +40,10 @@ class AppEntry extends StatelessWidget {
 
 class TopBar extends StatefulWidget {
   @override
-  State<StatefulWidget> createState() => _TopBarState();
+  State<TopBar> createState() => _TopBarState();
 }
 
-class _TopBarState extends State {
+class _TopBarState extends State<TopBar> {
   @override
   Widget build(BuildContext context) {
     final mediaQuerry = MediaQuery.of(context);

--- a/lib/providers/ScoresListProvider.dart
+++ b/lib/providers/ScoresListProvider.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:musescore/services/scores_service.dart';
+
+import '../data/drift_db.dart';
+
+class ScoreListNotifier extends StateNotifier<Map<String,List<Score>>>{
+  ScoreListNotifier(): super({});
+
+  void insertScore(ScoresCompanion score,String filter) async {
+    ScoreService servObj = ScoreService();
+    await servObj.insertScore(score);
+
+    Map<String,List<Score>> mappedScores = await getMappedScoresHelper(filter);
+
+    state = {...mappedScores};
+  }
+
+  void removeScore(List<Score> listOfScores, String filter) async{
+    List<int> listOfIds = [];
+    listOfScores.forEach((score) {listOfIds.add(score.id);});
+
+    ScoreService servObj = ScoreService();
+    await servObj.deleteListOfScores(listOfIds);
+
+    Map<String, List<Score>> mappedScores = await getMappedScoresHelper(filter);
+
+    state = {...mappedScores};
+
+  }
+
+  void getMappedScores(String filter) async {
+    Map<String, List<Score>> mappedScores = await getMappedScoresHelper(filter);
+    state = {...mappedScores};
+  }
+
+  Future<Map<String,List<Score>>> getMappedScoresHelper(String filter) async {
+    ScoreService servObj = ScoreService();
+    List<Score> listsOfScore = await servObj.getAllScores();
+    Map<String, List<Score>> mappedScores = {};
+    if (filter == 'composer') {
+      listsOfScore.forEach((score) {
+        if (mappedScores[score.composer] == null) {
+          mappedScores[score.composer] = [];
+        }
+        mappedScores[score.composer]!.add(score);
+      });
+    }
+    return mappedScores;
+  }
+}
+
+final scoresListProvider = StateNotifierProvider<ScoreListNotifier,Map<String,List<Score>>>((ref){
+  return ScoreListNotifier();
+});

--- a/lib/repositories/scores_repository.dart
+++ b/lib/repositories/scores_repository.dart
@@ -13,4 +13,8 @@ class ScoreRepo {
   Future<List<Score>> getAllScores() {
     return this.drift.allScoresDb;
   }
+
+  Future deleteListOfScores(List<int> listOfIds){
+    return this.drift.deleteListOfScoresDB(listOfIds);
+  }
 }

--- a/lib/services/scores_service.dart
+++ b/lib/services/scores_service.dart
@@ -13,4 +13,8 @@ class ScoreService {
   Future<List<Score>> getAllScores() {
     return this.repo.getAllScores();
   }
+
+  Future deleteListOfScores(List<int> listOfIds){
+    return this.repo.deleteListOfScores(listOfIds);
+  }
 }

--- a/lib/widgets/FilterScoresDrawer.dart
+++ b/lib/widgets/FilterScoresDrawer.dart
@@ -3,19 +3,18 @@ import 'package:musescore/themedata.dart';
 import 'package:file_picker/file_picker.dart';
 import '../data/drift_db.dart';
 import '../services/scores_service.dart';
-import './ScoreListTile.dart';
-
-class FilterScores extends StatefulWidget {
+import './ScoreTile.dart';
+class FilterScoresDrawer extends StatefulWidget {
   String headername;
-  List<ScoreListTile> scores;
+  List<ScoreTile> scores;
 
-  FilterScores(this.headername, this.scores);
+  FilterScoresDrawer(this.headername, this.scores);
 
   @override
-  State<FilterScores> createState() => _FilterScoresState();
+  State<FilterScoresDrawer> createState() => _FilterScoresDrawerState();
 }
 
-class _FilterScoresState extends State<FilterScores> {
+class _FilterScoresDrawerState extends State<FilterScoresDrawer> {
   //This is for search bar
   late TextEditingController _controller;
 
@@ -82,10 +81,7 @@ class _FilterScoresState extends State<FilterScores> {
                       backgroundColor: AppTheme.darkBackground,
                     )),
                 TextButton(
-                    // clicking on back button should lead back to ScoresDrawer
-                    // ie. the previous modal side sheet
-                    //needs to be fixed
-                    onPressed: () => {Navigator.pushNamed(context, '/')},
+                    onPressed: () => {Navigator.of(context).pop()},
                     child: const Text('Back'),
                     style: TextButton.styleFrom(
                       primary: AppTheme.accentMain,

--- a/lib/widgets/ScoreListTile.dart
+++ b/lib/widgets/ScoreListTile.dart
@@ -2,10 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:modal_side_sheet/modal_side_sheet.dart';
 import 'package:musescore/themedata.dart';
-import 'package:musescore/widgets/ScoreTile.dart';
-import 'package:musescore/widgets/ScoresDrawer.dart';
 import '../data/drift_db.dart';
-import '../services/scores_service.dart';
 import './FilterScoresDrawer.dart';
 
 
@@ -13,7 +10,6 @@ class ScoreListTile extends StatefulWidget {
   int numItems; // this might be removed since you can take length of listofScores
   String text;
   List<Score> listOfScores;
-  //VoidCallback mainfunction; // might be reintroduced
   VoidCallback editFunction;
   AsyncCallback deleteFunction;
 
@@ -25,23 +21,9 @@ class ScoreListTile extends StatefulWidget {
 
 class _ScoreListTileState extends State<ScoreListTile> {
 
-  // List<ScoreTile> createScoreTiles(){
-  //   List<ScoreTile> listOfScoreTileWidgets = [];
-  //   widget.listOfScores.forEach((score) => listOfScoreTileWidgets.add(ScoreTile(score.name, score,(){},(){},(){}
-  //   })));
-  //   return listOfScoreTileWidgets;
-  // }
-
-  List<int> testFunc(){
-    List<int> listOfIds = [];
-    widget.listOfScores.forEach((score) => listOfIds.add(score.id));
-    return listOfIds;
-  }
-
   @override
   Widget build(BuildContext context){
     final mediaQuery = MediaQuery.of(context);
-    //var scoreTiles = createScoreTiles();
     return ListTile(
       title: Text(
         widget.text,
@@ -64,22 +46,6 @@ class _ScoreListTileState extends State<ScoreListTile> {
       ),
       trailing: IconButton(
         onPressed: widget.deleteFunction,
-        // NOTE: This does not work as smooth as needed,
-        // SetState inside OnPressed doesn't update UI
-        // When you click composer tab, the UI updates.
-        // onPressed: () async {
-        //   List<int> listOfIds = testFunc();
-        //   ScoreService servObj = ScoreService();
-        //   await servObj.deleteListOfScores(listOfIds);
-        //   Navigator.of(context).pop();
-        //   showModalSideSheet(
-        //     context: context,
-        //     barrierDismissible: true,
-        //     withCloseControll: false,
-        //     body: ScoreDrawer(),
-        //     width: mediaQuery.size.width * 0.70,
-        //   );
-        //},
         icon: Icon(Icons.delete),
         color: AppTheme.maintheme().iconTheme.color,
       ),

--- a/lib/widgets/ScoreListTile.dart
+++ b/lib/widgets/ScoreListTile.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:modal_side_sheet/modal_side_sheet.dart';
 import 'package:musescore/themedata.dart';
@@ -14,7 +15,7 @@ class ScoreListTile extends StatefulWidget {
   List<Score> listOfScores;
   //VoidCallback mainfunction; // might be reintroduced
   VoidCallback editFunction;
-  VoidCallback deleteFunction;
+  AsyncCallback deleteFunction;
 
   ScoreListTile(this.numItems, this.text,this.listOfScores, this.editFunction,this.deleteFunction);
 
@@ -23,11 +24,13 @@ class ScoreListTile extends StatefulWidget {
 }
 
 class _ScoreListTileState extends State<ScoreListTile> {
-  List<ScoreTile> createScoreTiles(){
-    List<ScoreTile> listOfScoreTileWidgets = [];
-    widget.listOfScores.forEach((score) => listOfScoreTileWidgets.add(ScoreTile(score.name, score,(){},(){},(){})));
-    return listOfScoreTileWidgets;
-  }
+
+  // List<ScoreTile> createScoreTiles(){
+  //   List<ScoreTile> listOfScoreTileWidgets = [];
+  //   widget.listOfScores.forEach((score) => listOfScoreTileWidgets.add(ScoreTile(score.name, score,(){},(){},(){}
+  //   })));
+  //   return listOfScoreTileWidgets;
+  // }
 
   List<int> testFunc(){
     List<int> listOfIds = [];
@@ -38,7 +41,7 @@ class _ScoreListTileState extends State<ScoreListTile> {
   @override
   Widget build(BuildContext context){
     final mediaQuery = MediaQuery.of(context);
-    var scoreTiles = createScoreTiles();
+    //var scoreTiles = createScoreTiles();
     return ListTile(
       title: Text(
         widget.text,
@@ -60,30 +63,30 @@ class _ScoreListTileState extends State<ScoreListTile> {
         color: AppTheme.maintheme().iconTheme.color,
       ),
       trailing: IconButton(
-        //onPressed: widget.deleteFunction,
+        onPressed: widget.deleteFunction,
         // NOTE: This does not work as smooth as needed,
         // SetState inside OnPressed doesn't update UI
         // When you click composer tab, the UI updates.
-        onPressed: () async {
-          List<int> listOfIds = testFunc();
-          ScoreService servObj = ScoreService();
-          await servObj.deleteListOfScores(listOfIds);
-          Navigator.of(context).pop();
-          showModalSideSheet(
-            context: context,
-            barrierDismissible: true,
-            withCloseControll: false,
-            body: ScoreDrawer(),
-            width: mediaQuery.size.width * 0.70,
-          );
-        },
+        // onPressed: () async {
+        //   List<int> listOfIds = testFunc();
+        //   ScoreService servObj = ScoreService();
+        //   await servObj.deleteListOfScores(listOfIds);
+        //   Navigator.of(context).pop();
+        //   showModalSideSheet(
+        //     context: context,
+        //     barrierDismissible: true,
+        //     withCloseControll: false,
+        //     body: ScoreDrawer(),
+        //     width: mediaQuery.size.width * 0.70,
+        //   );
+        //},
         icon: Icon(Icons.delete),
         color: AppTheme.maintheme().iconTheme.color,
       ),
       onTap: (){
         showModalSideSheet(
           context: context, 
-          body: FilterScoresDrawer(widget.text,scoreTiles),
+          body: FilterScoresDrawer(widget.text, widget.listOfScores),
           width: mediaQuery.size.width * 0.70,
           withCloseControll: false,
         );

--- a/lib/widgets/ScoreListTile.dart
+++ b/lib/widgets/ScoreListTile.dart
@@ -1,17 +1,31 @@
 import 'package:flutter/material.dart';
-
+import 'package:modal_side_sheet/modal_side_sheet.dart';
 import 'package:musescore/themedata.dart';
+import 'package:musescore/widgets/ScoreTile.dart';
+import '../data/drift_db.dart';
+import 'FilterScoresDrawer.dart';
+
 
 class ScoreListTile extends StatelessWidget {
-  int numItems;
+  int numItems; // this might be removed since you can take length of listofScores
   String text;
-  VoidCallback mainfunction;
+  List<Score> listOfScores;
+  //VoidCallback mainfunction; // might be reintroduced
   VoidCallback editFunction;
+  VoidCallback deleteFunction;
 
-  ScoreListTile(this.numItems, this.text, this.mainfunction, this.editFunction);
+  ScoreListTile(this.numItems, this.text,this.listOfScores, this.editFunction,this.deleteFunction);
+
+  List<ScoreTile> createScoreTiles(){
+    List<ScoreTile> listOfScoreTileWidgets = [];
+    listOfScores.forEach((score) => listOfScoreTileWidgets.add(ScoreTile("score name", score,(){},(){},(){})));
+    return listOfScoreTileWidgets;
+  }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context){
+    final mediaQuery = MediaQuery.of(context);
+    var scoreTiles = createScoreTiles();
     return ListTile(
       title: Text(
         text,
@@ -32,11 +46,19 @@ class ScoreListTile extends StatelessWidget {
         icon: Icon(Icons.edit_outlined),
         color: AppTheme.maintheme().iconTheme.color,
       ),
-      trailing: Icon(
-        Icons.arrow_forward_ios,
+      trailing: IconButton(
+        onPressed: deleteFunction,
+        icon: Icon(Icons.delete),
         color: AppTheme.maintheme().iconTheme.color,
       ),
-      onTap: mainfunction,
+      onTap: (){
+        showModalSideSheet(
+          context: context, 
+          body: FilterScoresDrawer(text,scoreTiles),
+          width: mediaQuery.size.width * 0.70,
+          withCloseControll: false,
+        );
+      },
     );
   }
 }

--- a/lib/widgets/ScoreListTile.dart
+++ b/lib/widgets/ScoreListTile.dart
@@ -18,7 +18,7 @@ class ScoreListTile extends StatelessWidget {
 
   List<ScoreTile> createScoreTiles(){
     List<ScoreTile> listOfScoreTileWidgets = [];
-    listOfScores.forEach((score) => listOfScoreTileWidgets.add(ScoreTile("score name", score,(){},(){},(){})));
+    listOfScores.forEach((score) => listOfScoreTileWidgets.add(ScoreTile(score.name, score,(){},(){},(){})));
     return listOfScoreTileWidgets;
   }
 

--- a/lib/widgets/ScoreTile.dart
+++ b/lib/widgets/ScoreTile.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:musescore/themedata.dart';
+import '../data/drift_db.dart';
+
+class ScoreTile extends StatelessWidget {
+  String text;
+  Score scoreInfo;
+  VoidCallback mainfunction; // calls pdf viewer
+  VoidCallback editFunction; // calls edit ui widget
+  VoidCallback deleteFunction; // calls delete of score tile
+
+  ScoreTile(this.text, this.scoreInfo, this.mainfunction, this.editFunction, this.deleteFunction);
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(
+        text,
+        style: TextStyle(
+          fontWeight: AppTheme.headerFontWeight,
+          fontSize: 20,
+        ),
+      ),
+      leading: IconButton(
+        onPressed: editFunction,
+        icon: Icon(Icons.edit_outlined),
+        color: AppTheme.maintheme().iconTheme.color,
+      ),
+      trailing: IconButton(
+        onPressed: deleteFunction,
+        icon: Icon(Icons.delete),
+        color: AppTheme.maintheme().iconTheme.color,
+      ),
+      onTap: mainfunction,
+    );
+  }
+}

--- a/lib/widgets/ScoresDrawer.dart
+++ b/lib/widgets/ScoresDrawer.dart
@@ -58,7 +58,7 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
 
   List<ScoreListTile> createListOfScoreListTileWidgets(){
     List<ScoreListTile> listOfWidgets = [];
-    sortedScoresMap.forEach((key, listOfScores) => listOfWidgets.add(ScoreListTile(listOfScores.length, key, listOfScores,(){} ,(){})));
+    sortedScoresMap.forEach((key, listOfScores) => listOfWidgets.add(ScoreListTile(listOfScores.length, key, listOfScores,(){},(){})));
     return listOfWidgets;
   }
 

--- a/lib/widgets/ScoresDrawer.dart
+++ b/lib/widgets/ScoresDrawer.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:musescore/themedata.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:modal_side_sheet/modal_side_sheet.dart';
-
 import '../data/drift_db.dart';
 import '../services/scores_service.dart';
 import './ScoreListTile.dart';
@@ -60,7 +58,7 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
 
   List<ScoreListTile> createListOfScoreListTileWidgets(){
     List<ScoreListTile> listOfWidgets = [];
-    sortedScoresMap.forEach((k,v)=> listOfWidgets.add(ScoreListTile(v.length,k,(){}, (){})));
+    sortedScoresMap.forEach((key, listOfScores) => listOfWidgets.add(ScoreListTile(listOfScores.length, key, listOfScores,(){} ,(){})));
     return listOfWidgets;
   }
 
@@ -71,7 +69,6 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
 
   @override
   Widget build(BuildContext context) {
-    final mediaQuerry = MediaQuery.of(context);
     // This is for list tile containing the unique composer/genre/tags/labels
 
     ListView listOfScoreListTiles = ListView(

--- a/lib/widgets/ScoresDrawer.dart
+++ b/lib/widgets/ScoresDrawer.dart
@@ -58,7 +58,16 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
 
   List<ScoreListTile> createListOfScoreListTileWidgets(){
     List<ScoreListTile> listOfWidgets = [];
-    sortedScoresMap.forEach((key, listOfScores) => listOfWidgets.add(ScoreListTile(listOfScores.length, key, listOfScores,(){},(){})));
+    sortedScoresMap.forEach((key, listOfScores) => listOfWidgets.add(ScoreListTile(listOfScores.length, key, listOfScores,(){},()async{
+      // turn this into a delete function in this file to make it cleaner
+      List<int> listOfIds = [];
+      listOfScores.forEach((score) => listOfIds.add(score.id));
+      await ScoreService().deleteListOfScores(listOfIds);
+      Map<String,List<Score>> testing = await getMappedScores("composer");
+      setState(() {
+        sortedScoresMap = testing;
+      });
+    })));
     return listOfWidgets;
   }
 
@@ -116,7 +125,7 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
                       backgroundColor: AppTheme.darkBackground,
                     )),
                 TextButton(
-                    onPressed: () => {Navigator.pushNamed(context, '/')},
+                    onPressed: () => {Navigator.of(context).pop()},//Navigator.pushNamed(context, '/')}, // pushName vs pop?
                     child: const Text('Back'),
                     style: TextButton.styleFrom(
                       primary: AppTheme.accentMain,

--- a/lib/widgets/ScoresDrawer.dart
+++ b/lib/widgets/ScoresDrawer.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:musescore/providers/ScoresListProvider.dart';
 import 'package:musescore/themedata.dart';
 import 'package:file_picker/file_picker.dart';
 import '../data/drift_db.dart';
 import '../services/scores_service.dart';
 import './ScoreListTile.dart';
 
-class ScoreDrawer extends StatefulWidget {
-  @override
-  State<ScoreDrawer> createState() => _ScoresLibraryWidgetState();
-}
+class ScoreDrawer extends ConsumerStatefulWidget {
+  ScoreDrawer({Key? key}): super(key: key);
+   @override
+   ConsumerState<ScoreDrawer> createState() => _ScoresLibraryWidgetState();
+ }
 
-class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
+ class _ScoresLibraryWidgetState extends ConsumerState<ScoreDrawer> {
   //This is for changing color in Second Nav bar each button
   bool _hasBeenPressedComposer = true;
   bool _hasBeenPressedGenres = false;
@@ -23,8 +26,6 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
   //variable to initialize file picker object & hold the file object
   FilePickerResult? result;
   PlatformFile? file;
-
-  late Map<String,List<Score>> sortedScoresMap = {};
 
   //method called when the stateful widget is inserted in the widget tree
   //it will only run once and initilize and listeners/variables
@@ -42,38 +43,18 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
     super.dispose();
   }
 
-  Future<Map<String,List<Score>>> getMappedScores(String filter) async {
-    ScoreService servObj = ScoreService();
-    List<Score> listsOfScore = await servObj.getAllScores();
-    Map<String,List<Score>> mappedScores = {};
-
-    if(filter == 'composer'){
-      listsOfScore.forEach((score){
-        if(mappedScores[score.composer] == null){mappedScores[score.composer] = [];}
-        mappedScores[score.composer]!.add(score);
-      });
-    }
-    return mappedScores;
-  }
-
-  List<ScoreListTile> createListOfScoreListTileWidgets(){
-    List<ScoreListTile> listOfWidgets = [];
-    sortedScoresMap.forEach((key, listOfScores) => listOfWidgets.add(ScoreListTile(listOfScores.length, key, listOfScores,(){},()async{
-      // turn this into a delete function in this file to make it cleaner
-      List<int> listOfIds = [];
-      listOfScores.forEach((score) => listOfIds.add(score.id));
-      await ScoreService().deleteListOfScores(listOfIds);
-      Map<String,List<Score>> testing = await getMappedScores("composer");
-      setState(() {
-        sortedScoresMap = testing;
-      });
-    })));
-    return listOfWidgets;
-  }
-
   void setup() async {
-    sortedScoresMap = await getMappedScores("composer");
-    setState(() {});
+    super.initState();
+    ref.read(scoresListProvider.notifier).getMappedScores("composer");
+  }
+
+  List<ScoreListTile> createListOfScoreListTileWidgets() {
+    Map<String, List<Score>> mapSortedScores = ref.watch(scoresListProvider);
+    List<ScoreListTile> listOfWidgets = [];
+    mapSortedScores.forEach((key, listOfScores) => listOfWidgets.add(ScoreListTile(listOfScores.length, key, listOfScores, () {}, () async {
+          ref.read(scoresListProvider.notifier).removeScore(listOfScores, "composer");
+        })));
+    return listOfWidgets;
   }
 
   @override
@@ -109,15 +90,12 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
                       ScoreService servObj = ScoreService();
                       ScoresCompanion scoreObj = ScoresCompanion.insert(
                            name: file!.name, file: file?.path ?? "no path", composer: 'no composer');
-                      await servObj.insertScore(scoreObj);
+
+                      ref.read(scoresListProvider.notifier).insertScore(scoreObj,"composer"); // need to fix for dynamic if provider works
 
                       // use to test and show data storage in terminal
                       List<Score> listsOfScore = await servObj.getAllScores();
                       print(listsOfScore);
-
-                      sortedScoresMap = await getMappedScores("composer");
-
-                      setState(() {});
                     },
                     child: const Text('Import'),
                     style: TextButton.styleFrom(
@@ -144,15 +122,12 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
               children: <Widget>[
                 Expanded(
                     child: TextButton(
-                  onPressed: () async => {
-                    sortedScoresMap = await getMappedScores("composer"),
-                    setState(() {
-                      _hasBeenPressedComposer = true;
-                      _hasBeenPressedTags = false;
-                      _hasBeenPressedGenres = false;
-                      _hasBeenPressedLabels = false;
-                      //_onItemTapped(0);
-                    })
+                  onPressed: () async {
+                    ref.read(scoresListProvider.notifier).getMappedScores("composer");
+                    _hasBeenPressedComposer = true;
+                    _hasBeenPressedTags = false;
+                    _hasBeenPressedGenres = false;
+                    _hasBeenPressedLabels = false;
                   },
                   child: const Text('Composers',
                     overflow: TextOverflow.ellipsis,
@@ -167,14 +142,12 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
                 )),
                 Expanded(
                     child: TextButton(
-                  onPressed: () => {
-                    setState(() {
-                      _hasBeenPressedGenres = true;
-                      _hasBeenPressedComposer = false;
-                      _hasBeenPressedTags = false;
-                      _hasBeenPressedLabels = false;
-                      //_onItemTapped(1);
-                    })
+                  onPressed: () {
+                    ref.read(scoresListProvider.notifier).getMappedScores("test");
+                    _hasBeenPressedGenres = true;
+                    _hasBeenPressedComposer = false;
+                    _hasBeenPressedTags = false;
+                    _hasBeenPressedLabels = false;
                   },
                   child: const Text( 'Genres',
                     overflow: TextOverflow.ellipsis,
@@ -190,14 +163,12 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
                 )),
                 Expanded(
                     child: TextButton(
-                  onPressed: () => {
-                    setState(() {
-                      _hasBeenPressedTags = true;
-                      _hasBeenPressedComposer = false;
-                      _hasBeenPressedGenres = false;
-                      _hasBeenPressedLabels = false;
-                      //_onItemTapped(2);
-                    })
+                  onPressed: () {
+                    ref.read(scoresListProvider.notifier).getMappedScores("test");
+                    _hasBeenPressedTags = true;
+                    _hasBeenPressedComposer = false;
+                    _hasBeenPressedGenres = false;
+                    _hasBeenPressedLabels = false;
                   },
                   child: const Text('Tags',
                     overflow: TextOverflow.ellipsis,
@@ -213,14 +184,12 @@ class _ScoresLibraryWidgetState extends State<ScoreDrawer> {
                 )),
                 Expanded(
                     child: TextButton(
-                  onPressed: () => {
-                    setState(() {
-                      _hasBeenPressedTags = false;
-                      _hasBeenPressedComposer = false;
-                      _hasBeenPressedGenres = false;
-                      _hasBeenPressedLabels = true;
-                      //_onItemTapped(3);
-                    })
+                  onPressed: () {
+                    ref.read(scoresListProvider.notifier).getMappedScores("test");
+                    _hasBeenPressedTags = false;
+                    _hasBeenPressedComposer = false;
+                    _hasBeenPressedGenres = false;
+                    _hasBeenPressedLabels = true;
                   },
                   child: const Text('Labels',
                     overflow: TextOverflow.ellipsis,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   document_scanner_flutter: ^0.2.7
   drift: ^2.1.0
   file_picker: ^5.0.1
+  flutter_riverpod: ^2.0.1
   get_it: ^7.2.0
   image_picker: ^0.8.5+3
   modal_side_sheet: ^0.0.1


### PR DESCRIPTION
Overview
---
1. Connected filter score UI to score drawer widget (works dynamically)
2. Work flow is the following
    Score drawer widget dynamically creates a list of scoreListTile.
    ScoreListTile holds function/pathway to FilterScoresDrawer
    FilterScoresDrawer widget dynamically creates the scoreTiles.
3. Added bulk delete functionality

What's changed
---
0. Added Riverpod to rebuild UI dynamically.
1. Refactor Filter scores widget
2. Fixed bug on going back to previous modal sheet from filter score UI
3. Refactor scoreListTile widget and its functionality
4. Added new ScoreTile widget
5. Added delete button code from what was on test_filterScore branch
6. Added delete query for db

Screen shot
---
![FilterScoresDrawerV2](https://user-images.githubusercontent.com/57391125/198950448-608bde4e-0d2a-4ce0-b83a-d9dfb2a3c7fc.JPG)

